### PR TITLE
1 add q-capf-mode and q-capf-eldoc-mode minor modes

### DIFF
--- a/q-capf.el
+++ b/q-capf.el
@@ -464,7 +464,7 @@ and `q-capf-session-vars'."
   :keymap nil
   (if q-capf-eldoc-mode
       (progn
-        (eldoc-mode 1) ; enable eldoc-mode or else this does nothing
+        (eldoc-mode 1) ; enable `eldoc-mode' or else this does nothing
         (add-hook 'eldoc-documentation-functions #'q-capf-eldoc nil t))
     (remove-hook 'eldoc-documentation-functions #'q-capf-eldoc t)))
 

--- a/q-capf.el
+++ b/q-capf.el
@@ -349,6 +349,16 @@ Auto completes variables and functions with candidates from
                       (visual-line-mode))
                     (current-buffer)))))))))
 
+;;;###autoload
+(define-minor-mode q-capf-mode
+  "Adds `q-capf-completion-at-point' to `completion-at-point-functions'."
+  :init-value nil
+  :lighter " q-capf"
+  :keymap nil ; specify custom keybinding and/or function for `q-capf-refresh-cache'
+  (if q-capf-mode
+          (add-hook 'completion-at-point-functions #'q-capf-completion-at-point nil t)
+        (remove-hook 'completion-at-point-functions #'q-capf-completion-at-point t)))
+
 (defun q-capf--bounds ()
   "Return the bounds of a variable or function in q.
 If it cannot match a valid variable it will give begin and end bounds at point."
@@ -446,7 +456,15 @@ and `q-capf-session-vars'."
      :thing thing
      :face face)))
 
-(add-hook 'q-mode-hook (lambda () (add-hook 'eldoc-documentation-functions #'q-capf-eldoc nil t)))
+;;;###autoload
+(define-minor-mode q-capf-eldoc-mode
+  "Adds `q-capf-eldoc' to `eldoc-documentation-functions' hook."
+  :init-value nil
+  :lighter " q-capf-eldoc"
+  :keymap nil
+  (if q-capf-eldoc
+      (add-hook 'eldoc-documentation-functions #'q-capf-eldoc nil t)
+    (remove-hook 'eldoc-documentation-functions #'q-capf-eldoc t)))
 
 (provide 'q-capf)
 ;;; q-capf.el ends here

--- a/q-capf.el
+++ b/q-capf.el
@@ -462,7 +462,7 @@ and `q-capf-session-vars'."
   :init-value nil
   :lighter " q-capf-eldoc"
   :keymap nil
-  (if q-capf-eldoc
+  (if q-capf-eldoc-mode
       (add-hook 'eldoc-documentation-functions #'q-capf-eldoc nil t)
     (remove-hook 'eldoc-documentation-functions #'q-capf-eldoc t)))
 

--- a/q-capf.el
+++ b/q-capf.el
@@ -463,7 +463,9 @@ and `q-capf-session-vars'."
   :lighter " q-capf-eldoc"
   :keymap nil
   (if q-capf-eldoc-mode
-      (add-hook 'eldoc-documentation-functions #'q-capf-eldoc nil t)
+      (progn
+        (eldoc-mode 1) ; enable eldoc-mode or else this does nothing
+        (add-hook 'eldoc-documentation-functions #'q-capf-eldoc nil t))
     (remove-hook 'eldoc-documentation-functions #'q-capf-eldoc t)))
 
 (provide 'q-capf)


### PR DESCRIPTION
This allows for easier abstraction of adding/removing hooks.
Note that you obviously need to use eldoc-mode to see q-capf-eldoc.